### PR TITLE
Actuator prometheus grafana docker setup for the linux plebs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use a base image with Java
+FROM openjdk:17-jdk-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the Spring Boot jar file into the container
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+
+# Expose the port your Spring Boot application listens on
+EXPOSE 8080
+
+# Command to run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  mini-shopify:
+    image: mini-shopify
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    networks:
+      - monitoring
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090" # Expose Prometheus UI
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml # Mount Prometheus config
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000" # Expose Grafana UI
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,14 @@
             <version>5.3.0</version> <!-- Or latest version -->
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: 'mini-shopify'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      # linux: use ip of docker network
+      # mac/windows: use localhost:8080
+      - targets: ['172.17.0.1:8080'] # Use this to access localhost from Docker

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=*
 management.metrics.enable.http.server.requests=true
+management.endpoint.health.show-details=always
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=*
+management.metrics.enable.http.server.requests=true


### PR DESCRIPTION
DO NOT MERGE (at least for now)
## PR type

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Performance Optimization
- [ ] Documentation Update

## Description
<!--
A description of what this PR is, not how it does what it is supposed to do.
-->
Docker version of the stack, including prometheus actuator and grafana
look at the comments in prometheus.yml for platform specific settings. default is linux
To install:
- docker and docker compose required
- build the docker image of the app
- docker compose up -d
- access the app on localhost:8080
- access prometheus on localhost:9090
- access grafana on localhost:3000
- on grafana add data source ->prometheus
- in the config, the only things needed is the url which is http://prometheus:9090
- then make dashboards.
